### PR TITLE
Feat/number key shorcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Disable Player Number Shortcuts**: New feature to prevent number keys (0-9) from changing the video's playback position. This is useful for users who work on a second screen while a video is playing.
+
 
 ### Fixed
 - Improved detection of "Members Only" videos in the "related videos" section: now only hides `.yt-badge-shape--commerce` badges if they contain a `.yt-badge-shape__icon`, which is present on members-only badges but not on fundraiser/commerce badges. This avoids hiding fundraiser videos while still hiding members-only content in related lists.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -109,6 +109,16 @@
     "description": "Tooltip explaining the prevent Shorts loop feature"
   },
 
+  "featureDisableNumberShortcuts": {
+    "message": "Disable Player Number Shortcuts",
+    "description": "Title for the disable number keyboard shortcuts feature"
+  },
+
+  "tooltipDisableNumberShortcuts": {
+    "message": "Prevents number keys (0-9) from changing the video playback position. Useful to avoid accidental seeks when working on another screen.",
+    "description": "Tooltip for the disable number keyboard shortcuts feature"
+  },
+
   "optionAuto": {
     "message": "Auto",
     "description": "Option for automatic video quality selection"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -109,6 +109,16 @@
     "description": "Tooltip explaining the prevent Shorts loop feature"
   },
 
+  "featureDisableNumberShortcuts": {
+    "message": "Désactiver les raccourcis numériques du lecteur",
+    "description": "Title for the disable number keyboard shortcuts feature"
+  },
+
+  "tooltipDisableNumberShortcuts": {
+    "message": "Empêche les touches numériques (0-9) de modifier la position de lecture de la vidéo. Utile pour éviter les sauts accidentels en travaillant sur un autre écran.",
+    "description": "Tooltip for the disable number keyboard shortcuts feature"
+  },
+
   "optionAuto": {
     "message": "Auto",
     "description": "Option for automatic video quality selection"

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -109,6 +109,16 @@
     "description": "Tooltip explaining the prevent Shorts loop feature"
   },
 
+  "featureDisableNumberShortcuts": {
+    "message": "Disable Player Number Shortcuts",
+    "description": "Title for the disable number keyboard shortcuts feature"
+  },
+
+  "tooltipDisableNumberShortcuts": {
+    "message": "Prevents number keys (0-9) from changing the video playback position. Useful to avoid accidental seeks when working on another screen.",
+    "description": "Tooltip for the disable number keyboard shortcuts feature"
+  },
+
   "optionAuto": {
     "message": "Авто",
     "description": "Option for automatic video quality selection"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -59,6 +59,9 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
     },
     preventShortsLoop: {
         enabled: false
+    },
+    disableNumberShortcuts: {
+        enabled: false
     }
 };
 

--- a/src/content/disableNumberShortcuts/DisableNumberShortcuts.ts
+++ b/src/content/disableNumberShortcuts/DisableNumberShortcuts.ts
@@ -1,0 +1,54 @@
+/* 
+ * Copyright (C) 2025-present YouGo (https://github.com/youg-o)
+ * This program is licensed under the GNU Affero General Public License v3.0.
+ * You may redistribute it and/or modify it under the terms of the license.
+ * 
+ * Attribution must be given to the original author.
+ * This program is distributed without any warranty; see the license for details.
+ */
+
+import { playerLog } from '../../utils/logger';
+import { currentSettings } from '../index';
+
+// Flag to track if the event listener is active
+let isEventListenerActive = false;
+
+/**
+ * Keyboard event handler to block number shortcuts.
+ * @param e - The keyboard event.
+ */
+function keydownHandler(e: KeyboardEvent): void {
+    const target = e.target as HTMLElement;
+
+    // Do not interfere when typing in input fields
+    if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+    ) {
+        return;
+    }
+
+    // Block number keys (0-9) and numpad keys (0-9)
+    if ((e.code >= 'Digit0' && e.code <= 'Digit9') || (e.code >= 'Numpad0' && e.code <= 'Numpad9')) {
+        e.stopImmediatePropagation();
+        playerLog('Blocked a number key shortcut.');
+    }
+}
+
+/**
+ * Adds or removes the keydown event listener based on user settings.
+ */
+export function handleDisableNumberShortcuts(): void {
+    const shouldBeActive = currentSettings?.disableNumberShortcuts?.enabled ?? false;
+
+    if (shouldBeActive && !isEventListenerActive) {
+        window.addEventListener('keydown', keydownHandler, true);
+        isEventListenerActive = true;
+        playerLog('Number key shortcuts blocker has been activated.');
+    } else if (!shouldBeActive && isEventListenerActive) {
+        window.removeEventListener('keydown', keydownHandler, true);
+        isEventListenerActive = false;
+        playerLog('Number key shortcuts blocker has been deactivated.');
+    }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -54,7 +54,8 @@ function initializeVideoPlayerListener() {
         currentSettings?.subtitlesPreference.enabled ||
         currentSettings?.audioNormalizer.enabled ||
         currentSettings?.volume?.enabled ||
-        currentSettings?.audioTrack?.enabled
+        currentSettings?.audioTrack?.enabled ||
+        currentSettings?.disableNumberShortcuts?.enabled
     )) {
         setupVideoPlayerListener();
         videoPlayerListenerInitialized = true;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -395,6 +395,24 @@
                         </label>
                     </div>
                 </div>
+                <!-- Disable Number Keyboard Shortcuts -->
+                <div class="p-3 rounded-lg border border-gray-600 hover:bg-gray-600 transition-colors">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-2">
+                            <h2 class="text-sm font-medium text-white" data-i18n="featureDisableNumberShortcuts"></h2>
+                            <div class="relative group tooltip">
+                                <svg class="w-4 h-4 text-gray-400 cursor-help group hover:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
+                                </svg>
+                                <span class="absolute z-20 bottom-full left-0 ml-[-20px] mb-2 w-[220px] px-3 py-2 text-xs text-white bg-gray-900/95 rounded-md shadow-lg whitespace-normal opacity-0 pointer-events-none invisible group-hover:opacity-100 group-hover:visible transition-opacity" data-i18n="tooltipDisableNumberShortcuts"></span>
+                            </div>
+                        </div>
+                        <label class="relative inline-flex items-center cursor-pointer">
+                            <input type="checkbox" class="sr-only peer" id="disableNumberShortcutsFeature">
+                            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                        </label>
+                    </div>
+                </div>
             </div>
         </main>
         <footer class="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[300px] flex flex-col gap-2 pt-2 pb-2 bg-gray-700 border-t border-gray-600 z-50">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -41,6 +41,7 @@ const volumeContainer = document.getElementById('volumeContainer') as HTMLDivEle
 
 const hideShortsFeature = document.getElementById('hideShortsFeature') as HTMLInputElement;
 const preventShortsLoopFeature = document.getElementById('preventShortsLoopFeature') as HTMLInputElement;
+const disableNumberShortcutsFeature = document.getElementById('disableNumberShortcutsFeature') as HTMLInputElement;
 
 // Custom settings
 const audioNormalizerCustomContainer = document.getElementById('audioNormalizerCustomContainer') as HTMLDivElement;
@@ -336,6 +337,11 @@ async function loadSettings() {
             preventShortsLoopFeature.checked = settings.preventShortsLoop.enabled;
         }
 
+        // Disable Number Shortcuts setting
+        if (settings.disableNumberShortcuts) {
+            disableNumberShortcutsFeature.checked = settings.disableNumberShortcuts.enabled;
+        }
+
         // Duration rule settings
         durationRuleEnabled.checked = settings.videoSpeed.durationRuleEnabled ?? false;
         durationRuleType.value = settings.videoSpeed.durationRuleType ?? 'less';
@@ -397,6 +403,9 @@ async function saveSettings() {
         },
         preventShortsLoop: {
             enabled: preventShortsLoopFeature.checked
+        },
+        disableNumberShortcuts: {
+            enabled: disableNumberShortcutsFeature.checked
         }
     };
     
@@ -481,6 +490,7 @@ function initEventListeners() {
 
     hideShortsFeature.addEventListener('change', saveSettings);
     preventShortsLoopFeature.addEventListener('change', saveSettings);
+    disableNumberShortcutsFeature.addEventListener('change', saveSettings);
 
     durationRuleEnabled.addEventListener('change', saveSettings);
     durationRuleType.addEventListener('change', saveSettings);
@@ -553,4 +563,3 @@ document.addEventListener('DOMContentLoaded', () => {
     loadSettings();
     initEventListeners();
 });
-

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -429,6 +429,24 @@
                             </label>
                         </div>
                     </div>
+
+                    <!-- Disable Number Keyboard Shortcuts -->
+                    <div class="p-5 rounded-lg border border-gray-600 hover:bg-gray-600/30 transition-colors">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-2">
+                                <h2 class="text-lg font-medium text-white" data-i18n="featureDisableNumberShortcuts"></h2>
+                                <div class="relative group tooltip">
+                                    <svg class="w-5 h-5 text-gray-400 cursor-help group hover:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
+                                    </svg>
+                                    <span class="absolute z-20 bottom-full left-0 ml-[-20px] mb-2 w-[220px] px-3 py-2 text-sm text-white bg-gray-900/95 rounded-md shadow-lg whitespace-normal opacity-0 pointer-events-none invisible group-hover:opacity-100 group-hover:visible transition-opacity" data-i18n="tooltipDisableNumberShortcuts"></span>
+                                </div>
+                            </div>
+                            <label class="relative inline-flex items-center cursor-pointer">
+                                <input type="checkbox" class="sr-only peer" id="disableNumberShortcutsFeature">
+                                <div class="w-14 h-7 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-6 after:w-6 after:transition-all peer-checked:bg-blue-600"></div>
+                            </label>
+                        </div>
                     </div>
                 </div>
             </main>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -58,6 +58,9 @@ export interface ExtensionSettings {
     preventShortsLoop: {
         enabled: boolean;
     };
+    disableNumberShortcuts: {
+        enabled: boolean;
+    };
 }
 
 export interface Message {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -45,6 +45,10 @@ const LOG_STYLES = {
     SHORTS: {
         context: '[Shorts]',
         color: '#9c27b0'  // Purple
+    },
+    PLAYER: {
+        context: '[Player]',
+        color: '#f43f5e' // Rose
     }
 } as const;
 
@@ -101,6 +105,9 @@ const audioTrackErrorLog = createErrorLogger(LOG_STYLES.AUDIO_TRACK);
 const shortsLog = createLogger(LOG_STYLES.SHORTS);
 const shortsErrorLog = createErrorLogger(LOG_STYLES.SHORTS);
 
+const playerLog = createLogger(LOG_STYLES.PLAYER);
+const playerErrorLog = createErrorLogger(LOG_STYLES.PLAYER);
+
 export {
     coreLog,
     coreErrorLog,
@@ -119,5 +126,7 @@ export {
     audioTrackLog,
     audioTrackErrorLog,
     shortsLog,
-    shortsErrorLog
+    shortsErrorLog,
+    playerLog,
+    playerErrorLog
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -14,6 +14,7 @@ import { handleSubtitlesPreference } from "../content/subtitles/SubtitlesPrefere
 import { handleAudioNormalizer } from "../content/audionormalizer/AudioNormalizer";
 import { handleVolume } from "../content/volume/Volume";
 import { handleAudioTrack } from "../content/audioTrack/AudioTrack";
+import { handleDisableNumberShortcuts } from "../content/disableNumberShortcuts/DisableNumberShortcuts";
 
 
 export function applyVideoPlayerSettings(): void {
@@ -23,4 +24,5 @@ export function applyVideoPlayerSettings(): void {
     currentSettings?.audioNormalizer.enabled && handleAudioNormalizer();
     currentSettings?.volume.enabled && handleVolume();
     currentSettings?.audioTrack.enabled && handleAudioTrack();
+    handleDisableNumberShortcuts();
 }


### PR DESCRIPTION
**Disable Player Number Shortcuts**: New feature to prevent number keys (0-9) from changing the video's playback position. This is useful for users who work on a second screen while a video is playing.
